### PR TITLE
Update videostream to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "is-ascii": "^1.0.0",
     "mediasource": "^2.1.0",
     "stream-to-blob-url": "^2.0.0",
-    "videostream": "^2.0.0"
+    "videostream": "^2.3.0"
   },
   "devDependencies": {
     "brfs": "^1.4.1",


### PR DESCRIPTION
I was waiting for a greenkeeper PR to update videostream but it does seems to be enabled on this repo.
My concern is about the preload issues a was facing issue (jhiesey/videostream#22)
