### PR TITLE
Fix chrome issue with opus webm videos

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,7 +339,7 @@ function getCodec (name) {
     '.mkv': 'video/webm; codecs="avc1.640029, mp4a.40.5"',
     '.mp3': 'audio/mpeg',
     '.mp4': 'video/mp4; codecs="avc1.640029, mp4a.40.5"',
-    '.webm': 'video/webm; codecs="vorbis, vp8"'
+    '.webm': 'video/webm; codecs="opus, vorbis, vp8"'
   }[extname]
 }
 


### PR DESCRIPTION
On Chromium/Chrome the media could not be loaded with webm videos that have opus audio